### PR TITLE
fix: update module syntax for zig 0.11.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 
 pub fn build(b: *std.build.Builder) void {
-    b.addModule(.{
-        .name = "extras",
-        .source_file = .{ .path = "src/lib.zig" },
-    });
+    _ = b.addModule(
+        "extras",
+        .{ .source_file = .{ .path = "src/lib.zig" } },
+    );
 }


### PR DESCRIPTION
Hello! I've updated the module syntax for Zig v0.11.0. 

This is in tandem with https://github.com/nektro/zig-time/pull/6

Hope these changes are okay.

And thank you for all the brilliant projects! :)

